### PR TITLE
The webacl association terraform resource type...

### DIFF
--- a/.github/workflows/tf-build-DEV.yml
+++ b/.github/workflows/tf-build-DEV.yml
@@ -26,7 +26,7 @@ jobs:
   terraform:
     name: "DEV tf infrastructure deployment"
     runs-on: ubuntu-latest
-    timeout-minutes: 35
+    timeout-minutes: 45
     defaults:
       run:
         shell: bash

--- a/.github/workflows/tf-build-PROD.yml
+++ b/.github/workflows/tf-build-PROD.yml
@@ -26,7 +26,7 @@ jobs:
   terraform:
     name: "PROD tf infrastructure deployment"
     runs-on: ubuntu-latest
-    timeout-minutes: 35
+    timeout-minutes: 45
     defaults:
       run:
         shell: bash

--- a/tf-be/main.tf
+++ b/tf-be/main.tf
@@ -400,5 +400,10 @@ resource "aws_lambda_permission" "apigw_lambda" {
 resource "aws_wafv2_web_acl_association" "apigwwebacl" {
   resource_arn = aws_api_gateway_stage.lambdaAPI.arn
   web_acl_arn = aws_wafv2_web_acl.apigwwebacl.arn
+  depends_on = [ aws_api_gateway_stage.lambdaAPI, aws_wafv2_web_acl.apigwwebacl ]
+
+  timeouts {
+    create = "20m"
+  } 
 }
 


### PR DESCRIPTION
is prone to not deploying due to a race condition. By default it will only try to deploy for 5 minutes. The Terraform AWS Provider has added functionality to the resource type to make the creation timeout configurable to address this issue. (see: https://github.com/hashicorp/terraform-provider-aws/pull/30002)

Adjusted the timeout for webacl-association creation to 20 minutes, and increased the overally Terraform deploy workflow timeouts to 45 minutes