### PR TITLE
Changed the way the reusable workflow is called

### DIFF
--- a/.github/workflows/tf-build-PROD.yml
+++ b/.github/workflows/tf-build-PROD.yml
@@ -113,5 +113,5 @@ jobs:
   deletedev:
     name: "PROD Delete Dev Deployment"
     needs: terraform
-    uses: ./.github/workflows/tf-destroy-DEV-workflow-call.yml
+    uses: justicecorp/CRC_Prod/.github/workflows/tf-destroy-DEV-workflow-call.yml@Test
     


### PR DESCRIPTION
- Can be called 2 ways: as a local workflow, or as an external workflow.
- When using a local workflow, it always uses the current commit/branch (can't specify a branch)
- When using an external workflow, it requires you actually specify a commit/branch/etc

Trying to call it as an external workflow so I can specify the Test branch