### PR TITLE
Changed the Terraform naming of the s3 html bucket

### DIFF
--- a/tf-fe/main.tf
+++ b/tf-fe/main.tf
@@ -49,8 +49,8 @@ resource "random_password" "refererstring" {
 }
 
 resource "random_integer" "s3suffix" {
-  min = 3
-  max = 6
+  min = 99
+  max = 9999
 }
 
 

--- a/tf-main/main.tf
+++ b/tf-main/main.tf
@@ -15,7 +15,7 @@ module "webapp-be" {
 
 module "webapp-fe" {
   source          = "../tf-fe"
-  BucketName      = var.BucketName
+  BucketName      = "${var.WebSiteHostName}.${var.HostedZone}"
   WebCodeVersion  = var.WebCodeVersion
   HostedZone      = var.HostedZone
   WebSiteHostName = var.WebSiteHostName

--- a/tf-main/terraform.tfvars
+++ b/tf-main/terraform.tfvars
@@ -9,13 +9,14 @@ APIGWName                  = "VisitorCounterAPICombChange"
 DDBDateAttrName            = "UniqueVisitStampCombChange"
 DDBTimestampUniqueDiffDays = 14
 # ONLY LOWERCASE ALPHANUMERIC CHARS and HYPHENS ALLOWED
-BucketName     = "visitorcounter-justicecorp-gha"
 WebCodeVersion = "3.0"
 
 
 # THIS SHOULD BE PASSED IN THROUGH THE COMMAND LINE
+# This is used for the s3 bucketname - make sure it follows s3 naming conventions
 #WebSiteHostName = "resumerealcomb"
 
 # THIS SHOULD BE PASSED IN THROUGH THE COMMAND LINE
 # Must have the hosted zone pre-created
+# This is used for the s3 bucketname - make sure it follows s3 naming conventions
 #HostedZone      = "dev.justicecorp.org"

--- a/tf-main/variables.tf
+++ b/tf-main/variables.tf
@@ -51,12 +51,6 @@ variable "APIGWName" {
   type = string
 }
 
-# The name of the bucket that will be created to host the static website
-# ONLY LOWERCASE ALPHANUMERIC CHARS and HYPHENS ALLOWED
-variable "BucketName" {
-  type = string
-}
-
 # A version string that will be used to version the html and js files. This makes it easier to invalidate caches without having to 
 # actually invalidate the cache through CF
 # Expected Format: "n.m" where n and m are integers
@@ -67,6 +61,7 @@ variable "WebCodeVersion" {
 # The name of a public hosted zone that is hosted in Route 53. We will use this variable to import an existing hosted zone 
 # as a data source, and use that to create DNS Records and Certs
 # Expected Format: exa. dev.justicecorp.org
+# KEEP THIS LOWERCASE (it is used for naming of several resources)
 variable "HostedZone" {
   type = string
 }
@@ -74,6 +69,7 @@ variable "HostedZone" {
 # The desired hostname for the Alias record to the CloudFront distribution
 # The ultiamte format of the DNS Record will be: <WebSiteHostName>.<HostedZone>
 # Expected Format: any valid hostname from the DNS perspective
+# KEEP THIS LOWERCASE (it is used for naming of several resources)
 variable "WebSiteHostName" {
   type = string
 }


### PR DESCRIPTION
- On the last run it hit a naming conflict because the naming convention allowed for that. Now it is unlikely that a conflict will occur.

Removed the BucketName Terraform variable because it is not really needed. Now I use the DNS of the website with a random 2-4 digit integer appended as the bucket name.